### PR TITLE
Removing ScriptBlockInvocationLogging

### DIFF
--- a/PSSecDSC.ps1
+++ b/PSSecDSC.ps1
@@ -71,7 +71,9 @@ Param(
             Ensure    = 'Present'
         }
 
-        # Remove this setting to descrease log volume
+        # Enable this setting to log start / stop events. Not usually recommended, as it causes
+        # a significant impact on log volume
+        <#
         Registry ScriptBlockInvocationLogging
         {
             Key       = 'HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging'
@@ -80,6 +82,7 @@ Param(
             ValueType = 'String'
             Ensure    = 'Present'
         }
+        #>
 
         Script PowerShellLogSize
         {


### PR DESCRIPTION
Removing the invocation logging setting, as the log volume impact is only useful if, for example, you are doing forensic analysis on a system that is known to be compromised.